### PR TITLE
Return user objects from APIs instead of emails

### DIFF
--- a/app/controllers/login_controller.py
+++ b/app/controllers/login_controller.py
@@ -21,7 +21,7 @@ class LoginController():
 
         if is_password_valid:
             create_session(email)
-            return jsonify({'user': user.serialize()})
+            return jsonify(user.serialize())
         else:
             delete_session()
             return '', 401

--- a/app/controllers/login_controller.py
+++ b/app/controllers/login_controller.py
@@ -1,4 +1,4 @@
-from flask import jsonify, request, session
+from flask import jsonify, request
 from app.models import User
 from app.util.password_util import validate_password
 from app.util.session_util import create_session, delete_session
@@ -21,7 +21,7 @@ class LoginController():
 
         if is_password_valid:
             create_session(email)
-            return jsonify(email=session['email'])
+            return jsonify({'user': user.serialize()})
         else:
             delete_session()
             return '', 401

--- a/app/controllers/login_controller.py
+++ b/app/controllers/login_controller.py
@@ -21,7 +21,7 @@ class LoginController():
 
         if is_password_valid:
             create_session(email)
-            return jsonify(user.serialize())
+            return jsonify(user.to_dict())
         else:
             delete_session()
             return '', 401

--- a/app/controllers/logout_controller.py
+++ b/app/controllers/logout_controller.py
@@ -1,7 +1,9 @@
+from flask import jsonify
+
 from app.util.session_util import delete_session
 
 
 class LogoutController():
     def handle(self):
         delete_session()
-        return ''
+        return jsonify(user=None)

--- a/app/controllers/logout_controller.py
+++ b/app/controllers/logout_controller.py
@@ -1,9 +1,7 @@
-from flask import jsonify
-
 from app.util.session_util import delete_session
 
 
 class LogoutController():
     def handle(self):
         delete_session()
-        return jsonify(user=None)
+        return ''

--- a/app/controllers/signup_controller.py
+++ b/app/controllers/signup_controller.py
@@ -17,4 +17,4 @@ class SignupController():
         db.session.commit()
 
         create_session(email)
-        return jsonify(user.serialize())
+        return jsonify(user.to_dict())

--- a/app/controllers/signup_controller.py
+++ b/app/controllers/signup_controller.py
@@ -17,4 +17,4 @@ class SignupController():
         db.session.commit()
 
         create_session(email)
-        return jsonify(email=email, is_session_active=True)
+        return jsonify(user=user.serialize(), is_session_active=True)

--- a/app/controllers/signup_controller.py
+++ b/app/controllers/signup_controller.py
@@ -17,4 +17,4 @@ class SignupController():
         db.session.commit()
 
         create_session(email)
-        return jsonify(user=user.serialize(), is_session_active=True)
+        return jsonify(user.serialize())

--- a/app/models.py
+++ b/app/models.py
@@ -18,7 +18,7 @@ class User(db.Model):
     def __repr__(self):
         return '<User {}: {}>'.format(self.id, self.email)
 
-    def serialize(self):
+    def to_dict(self):
         return {
             'id': self.id,
             'email': self.email
@@ -39,7 +39,7 @@ class MoviePreference(db.Model):
         self.user = user
         self.external_movie_id = external_movie_id
 
-    def serialize(self):
+    def to_dict(self):
         return {
             'id': self.id,
             'user_id': self.user_id,

--- a/app/models.py
+++ b/app/models.py
@@ -18,6 +18,12 @@ class User(db.Model):
     def __repr__(self):
         return '<User {}: {}>'.format(self.id, self.email)
 
+    def serialize():
+        return {
+            'id': self.id,
+            'email': self.email
+        }
+
 
 class MoviePreference(db.Model):
     __tablename__ = 'movie_preferences'
@@ -32,3 +38,10 @@ class MoviePreference(db.Model):
     def __init__(self, user, external_movie_id):
         self.user = user
         self.external_movie_id = external_movie_id
+
+    def serialize():
+        return {
+            'id': self.id,
+            'user_id': self.user_id,
+            'external_movie_id': self.external_movie_id
+        }

--- a/app/models.py
+++ b/app/models.py
@@ -18,7 +18,7 @@ class User(db.Model):
     def __repr__(self):
         return '<User {}: {}>'.format(self.id, self.email)
 
-    def serialize():
+    def serialize(self):
         return {
             'id': self.id,
             'email': self.email
@@ -39,7 +39,7 @@ class MoviePreference(db.Model):
         self.user = user
         self.external_movie_id = external_movie_id
 
-    def serialize():
+    def serialize(self):
         return {
             'id': self.id,
             'user_id': self.user_id,

--- a/app/routes.py
+++ b/app/routes.py
@@ -26,7 +26,7 @@ def serve(path):
 @app.route('/session', methods=['GET'])
 def get_session():
     if is_user_logged_in():
-        return jsonify(user=get_current_session_user().serialize())
+        return jsonify(user=get_current_session_user().to_dict())
     else:
         return jsonify(user=None)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import jsonify, send_from_directory, session
+from flask import jsonify, send_from_directory
 
 from app import app, BUILD_DIR
 from app.controllers import (
@@ -7,7 +7,11 @@ from app.controllers import (
     MovieSearchController,
     SignupController
 )
-from app.util.session_util import is_user_logged_in, login_required
+from app.util.session_util import (
+    get_current_session_user,
+    is_user_logged_in,
+    login_required
+)
 
 
 # For all routes, return index.html (so that React Router can handle routing).
@@ -22,9 +26,9 @@ def serve(path):
 @app.route('/session', methods=['GET'])
 def get_session():
     if is_user_logged_in():
-        return jsonify(email=session['email'])
+        return jsonify(user=get_current_session_user().serialize())
     else:
-        return jsonify(email='')
+        return jsonify(user=None)
 
 
 @app.route('/login', methods=['POST'])

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,21 +1,22 @@
 import React, { ChangeEvent, useState, useEffect } from "react";
 
 import logo from "../logo.svg";
+import { User } from "../types";
 
 const HomePage = (): JSX.Element => {
-  const [email, setEmail] = useState("");
+  const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
     fetch("/session")
       .then(response => response.json())
-      .then((data: { email: string }) => {
-        setEmail(data.email);
+      .then((data: { user: User }) => {
+        setUser(data.user);
       });
   }, []);
 
   const handleLogout = () => {
     fetch("/logout", { method: "POST" }).then(() => {
-      setEmail("");
+      setUser(null);
     });
   };
 
@@ -24,9 +25,9 @@ const HomePage = (): JSX.Element => {
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <h1>Kvasir Movies</h1>
-        {Boolean(email) && <p>Welcome back, {email}!</p>}
+        {user !== null && <p>Welcome back, {user.email}!</p>}
         <p>Find 🎬 with 👫 :D</p>
-        {email ? (
+        {user ? (
           <button onClick={handleLogout}>Log Out</button>
         ) : (
           <>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ const HomePage = (): JSX.Element => {
   useEffect(() => {
     fetch("/session")
       .then(response => response.json())
-      .then((data: { user: User }) => {
+      .then((data: { user: User | null }) => {
         setUser(data.user);
       });
   }, []);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -27,8 +27,8 @@ export default function LoginPage(): JSX.Element {
           );
         }
       })
-      .then((data: { user: User }) => {
-        setsessionUser(data.user);
+      .then((user: User) => {
+        setsessionUser(user);
       })
       .catch(errorMessage => alert(errorMessage));
   }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,11 +2,12 @@ import React, { useState } from "react";
 import { Redirect } from "react-router";
 
 import useFormInput from "../hooks/useFormInput";
+import { User } from "../types";
 
 export default function LoginPage(): JSX.Element {
   const email = useFormInput("");
   const password = useFormInput("");
-  const [sessionEmail, setSessionEmail] = useState("");
+  const [sessionUser, setsessionUser] = useState<User | null>(null);
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>): void {
     event.preventDefault();
@@ -26,13 +27,13 @@ export default function LoginPage(): JSX.Element {
           );
         }
       })
-      .then((data: { email: string }) => {
-        setSessionEmail(data.email);
+      .then((data: { user: User }) => {
+        setsessionUser(data.user);
       })
       .catch(errorMessage => alert(errorMessage));
   }
 
-  return sessionEmail ? (
+  return sessionUser ? (
     <Redirect to="/" />
   ) : (
     <form onSubmit={handleSubmit}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: number;
+  email: string;
+}


### PR DESCRIPTION
To add user movie preferences from the front-end, it's useful to have the user object there instead of just the email (so we can be REST-y and use user IDs). This PR lays some groundwork for that, so that login, logout, sign up, etc all use user objects instead of just emails.