### PR TITLE
Allow users to specify negative preferences

### DIFF
--- a/app/controllers/movie_preference_controller.py
+++ b/app/controllers/movie_preference_controller.py
@@ -17,10 +17,9 @@ class MoviePreferenceController():
 
         return jsonify(mp.to_dict())
 
-    def update(self, user):
+    def update(self, user, movie_preference_id):
         data = request.get_json()
-        movie_preference_id = data.get('moviePreferenceId', None)
-        preference_type = data.get('preferenceType')
+        preference_type = data.get('preference_type')
         if not movie_preference_id:
             abort(400)
 
@@ -43,6 +42,11 @@ class MoviePreferenceController():
             movie_preference_dict = mp.to_dict()
             movie_preference_dict.update({"title": external_movie["title"]})
             movies.append(movie_preference_dict)
+
+        def sort_by_title(movie):
+            return movie["title"]
+
+        movies.sort(key=sort_by_title)
 
         return jsonify({'movies': movies})
 

--- a/app/controllers/movie_preference_controller.py
+++ b/app/controllers/movie_preference_controller.py
@@ -43,10 +43,7 @@ class MoviePreferenceController():
             movie_preference_dict.update({"title": external_movie["title"]})
             movies.append(movie_preference_dict)
 
-        def sort_by_title(movie):
-            return movie["title"]
-
-        movies.sort(key=sort_by_title)
+        movies.sort(key=lambda m: m["title"])
 
         return jsonify({'movies': movies})
 

--- a/app/controllers/movie_preference_controller.py
+++ b/app/controllers/movie_preference_controller.py
@@ -17,6 +17,23 @@ class MoviePreferenceController():
 
         return jsonify(mp.to_dict())
 
+    def update(self, user):
+        data = request.get_json()
+        movie_preference_id = data.get('moviePreferenceId', None)
+        preference_type = data.get('preferenceType')
+        if not movie_preference_id:
+            abort(400)
+
+        mp = MoviePreference.query\
+            .filter(MoviePreference.id == movie_preference_id)\
+            .filter(MoviePreference.user_id == user.id)\
+            .one_or_none()
+
+        mp.preference_type = preference_type
+        db.session.commit()
+
+        return jsonify(mp.to_dict())
+
     def get(self, user):
         user_movie_preferences = user.movies
 

--- a/app/models.py
+++ b/app/models.py
@@ -54,5 +54,6 @@ class MoviePreference(db.Model):
         return {
             'id': self.id,
             'user_id': self.user_id,
-            'external_movie_id': self.external_movie_id
+            'external_movie_id': self.external_movie_id,
+            'preference_type': self.preference_type.value,
         }

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,8 @@
+import enum
+
 from app import db
 from app.util.password_util import hash_password
-from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import Column, Enum, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 
@@ -25,11 +27,17 @@ class User(db.Model):
         }
 
 
+class PreferenceTypes(enum.Enum):
+    positive = 'positive'
+    negative = 'negative'
+
+
 class MoviePreference(db.Model):
     __tablename__ = 'movie_preferences'
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     external_movie_id = Column(String(20), nullable=False)
+    preference_type = Column(Enum(PreferenceTypes), nullable=False, default=PreferenceTypes.positive)
 
     __table_args__ = (
         UniqueConstraint('user_id', 'external_movie_id', name='user_and_external_movie'),
@@ -37,9 +45,10 @@ class MoviePreference(db.Model):
 
     user = relationship("User", back_populates="movies")
 
-    def __init__(self, user, external_movie_id):
+    def __init__(self, user, external_movie_id, preference_type=PreferenceTypes.positive):
         self.user = user
         self.external_movie_id = external_movie_id
+        self.preference_type = preference_type
 
     def to_dict(self):
         return {

--- a/app/models.py
+++ b/app/models.py
@@ -55,5 +55,5 @@ class MoviePreference(db.Model):
             'id': self.id,
             'user_id': self.user_id,
             'external_movie_id': self.external_movie_id,
-            'preference_type': self.preference_type.value,
+            'preferenceType': self.preference_type.value,
         }

--- a/app/routes.py
+++ b/app/routes.py
@@ -67,10 +67,10 @@ def create_movie_preference(user):
     return MoviePreferenceController().create(user)
 
 
-@app.route('/users/<user_id>/movie-preferences', methods=['PUT'])
+@app.route('/users/<user_id>/movie-preferences/<movie_preference_id>', methods=['PUT'])
 @authorization_required
-def update_movie_preference(user):
-    return MoviePreferenceController().update(user)
+def update_movie_preference(user, movie_preference_id):
+    return MoviePreferenceController().update(user, movie_preference_id)
 
 
 @app.route('/users/<user_id>/movie-preferences/<movie_preference_id>', methods=['DELETE'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -67,7 +67,7 @@ def create_movie_preference(user):
     return MoviePreferenceController().create(user)
 
 
-@app.route('/users/<user_id>/movie-preferences/<movie_preference_id>', methods=['PUT'])
+@app.route('/users/<user_id>/movie-preferences/<movie_preference_id>', methods=['PATCH'])
 @authorization_required
 def update_movie_preference(user, movie_preference_id):
     return MoviePreferenceController().update(user, movie_preference_id)

--- a/app/routes.py
+++ b/app/routes.py
@@ -67,6 +67,12 @@ def create_movie_preference(user):
     return MoviePreferenceController().create(user)
 
 
+@app.route('/users/<user_id>/movie-preferences', methods=['PUT'])
+@authorization_required
+def update_movie_preference(user):
+    return MoviePreferenceController().update(user)
+
+
 @app.route('/users/<user_id>/movie-preferences/<movie_preference_id>', methods=['DELETE'])
 @authorization_required
 def delete_movie_preference(user, movie_preference_id):

--- a/migrations/versions/b63f44d5fcdb_.py
+++ b/migrations/versions/b63f44d5fcdb_.py
@@ -1,0 +1,37 @@
+"""Add preference_type to movie_preferences
+
+Revision ID: b63f44d5fcdb
+Revises: 863518d37297
+Create Date: 2019-03-30 16:29:34.214580
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from app.models import PreferenceTypes
+
+
+# revision identifiers, used by Alembic.
+revision = 'b63f44d5fcdb'
+down_revision = '863518d37297'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    preference_enum = postgresql.ENUM('positive', 'negative', name='preference_type')
+    preference_enum.create(op.get_bind())
+    op.add_column(
+        'movie_preferences',
+        sa.Column(
+            'preference_type',
+            sa.Enum('positive', 'negative', name='preference_type'),
+        )
+    )
+    op.execute("UPDATE movie_preferences SET preference_type = 'positive'")
+    op.alter_column('movie_preferences', 'preference_type', nullable=False)
+
+
+def downgrade():
+    op.drop_column('movie_preferences', 'preference_type')

--- a/src/App.css
+++ b/src/App.css
@@ -111,3 +111,18 @@ form {
 .deleteIcon:hover {
   cursor: pointer;
 }
+
+.preferenceIcon {
+  cursor: pointer;
+  font-size: 40px;
+}
+
+.movieOptionWrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.movieTitle {
+  padding-left: 10px;
+}

--- a/src/components/MovieList.tsx
+++ b/src/components/MovieList.tsx
@@ -20,7 +20,7 @@ export default function MovieList(props: {
         <div className="movieOption" key={index}>
           <div className="movieOptionWrapper">
             <MoviePreferenceType
-              id={movie.id}
+              movie_preference_id={movie.id}
               preference={movie.preference_type}
               setMovies={props.setMovies}
               user={props.user}

--- a/src/components/MovieList.tsx
+++ b/src/components/MovieList.tsx
@@ -18,13 +18,15 @@ export default function MovieList(props: {
       My movies:
       {props.movies.map((movie, index) => (
         <div className="movieOption" key={index}>
-          <MoviePreferenceType
-            id={movie.id}
-            preference={movie.preference_type}
-            setMovies={props.setMovies}
-            user={props.user}
-          />
-          {movie.title}
+          <div className="movieOptionWrapper">
+            <MoviePreferenceType
+              id={movie.id}
+              preference={movie.preference_type}
+              setMovies={props.setMovies}
+              user={props.user}
+            />
+            <div className="movieTitle">{movie.title}</div>
+          </div>
           <img
             className="deleteIcon"
             src={deleteIcon}

--- a/src/components/MovieList.tsx
+++ b/src/components/MovieList.tsx
@@ -3,6 +3,7 @@ import deleteIcon from "../images/x_icon_light.svg";
 
 import { MoviePreference, SetMovies, User } from "../types";
 import { deleteMovie } from "../network/requests";
+import MoviePreferenceType from "./MoviePreferenceType";
 
 export default function MovieList(props: {
   user: User;
@@ -17,6 +18,10 @@ export default function MovieList(props: {
       My movies:
       {props.movies.map((movie, index) => (
         <div className="movieOption" key={index}>
+          <MoviePreferenceType
+            id={movie.id}
+            preference={movie.preference_type}
+          />
           {movie.title}
           <img
             className="deleteIcon"

--- a/src/components/MovieList.tsx
+++ b/src/components/MovieList.tsx
@@ -21,7 +21,7 @@ export default function MovieList(props: {
           <div className="movieOptionWrapper">
             <MoviePreferenceType
               movie_preference_id={movie.id}
-              preference={movie.preference_type}
+              preference={movie.preferenceType}
               setMovies={props.setMovies}
               user={props.user}
             />

--- a/src/components/MovieList.tsx
+++ b/src/components/MovieList.tsx
@@ -21,6 +21,8 @@ export default function MovieList(props: {
           <MoviePreferenceType
             id={movie.id}
             preference={movie.preference_type}
+            setMovies={props.setMovies}
+            user={props.user}
           />
           {movie.title}
           <img

--- a/src/components/MoviePreferenceType.tsx
+++ b/src/components/MoviePreferenceType.tsx
@@ -4,12 +4,12 @@ import { updateMoviePreference } from "../network/requests";
 import { PreferenceType, SetMovies, User } from "../types";
 
 export default function MoviePreferenceType({
-  id,
+  movie_preference_id,
   preference,
   setMovies,
   user
 }: {
-  id: number;
+  movie_preference_id: number;
   preference: PreferenceType;
   setMovies: SetMovies;
   user: User;
@@ -19,7 +19,12 @@ export default function MoviePreferenceType({
       <div
         className="preferenceIcon"
         onClick={() =>
-          updateMoviePreference(id, user, PreferenceType.negative, setMovies)
+          updateMoviePreference(
+            movie_preference_id,
+            user,
+            PreferenceType.negative,
+            setMovies
+          )
         }
       >
         ✅
@@ -30,7 +35,12 @@ export default function MoviePreferenceType({
       <div
         className="preferenceIcon"
         onClick={() =>
-          updateMoviePreference(id, user, PreferenceType.positive, setMovies)
+          updateMoviePreference(
+            movie_preference_id,
+            user,
+            PreferenceType.positive,
+            setMovies
+          )
         }
       >
         🔴

--- a/src/components/MoviePreferenceType.tsx
+++ b/src/components/MoviePreferenceType.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { PreferenceType } from "../types";
+
+export default function MoviePreferenceType({
+  id,
+  preference
+}: {
+  id: number;
+  preference: PreferenceType;
+}): JSX.Element {
+  if (preference == PreferenceType.positive) {
+    return <div>👍</div>;
+  } else {
+    return <div>👎</div>;
+  }
+}

--- a/src/components/MoviePreferenceType.tsx
+++ b/src/components/MoviePreferenceType.tsx
@@ -1,17 +1,38 @@
 import React from "react";
 
-import { PreferenceType } from "../types";
+import { updateMoviePreference } from "../network/requests";
+import { PreferenceType, SetMovies, User } from "../types";
 
 export default function MoviePreferenceType({
   id,
-  preference
+  preference,
+  setMovies,
+  user
 }: {
   id: number;
   preference: PreferenceType;
+  setMovies: SetMovies;
+  user: User;
 }): JSX.Element {
   if (preference == PreferenceType.positive) {
-    return <div>👍</div>;
+    return (
+      <div
+        onClick={() =>
+          updateMoviePreference(id, user, PreferenceType.negative, setMovies)
+        }
+      >
+        👍
+      </div>
+    );
   } else {
-    return <div>👎</div>;
+    return (
+      <div
+        onClick={() =>
+          updateMoviePreference(id, user, PreferenceType.positive, setMovies)
+        }
+      >
+        👎
+      </div>
+    );
   }
 }

--- a/src/components/MoviePreferenceType.tsx
+++ b/src/components/MoviePreferenceType.tsx
@@ -22,7 +22,7 @@ export default function MoviePreferenceType({
           updateMoviePreference(id, user, PreferenceType.negative, setMovies)
         }
       >
-        👍
+        ✅
       </div>
     );
   } else {
@@ -33,7 +33,7 @@ export default function MoviePreferenceType({
           updateMoviePreference(id, user, PreferenceType.positive, setMovies)
         }
       >
-        👎
+        🔴
       </div>
     );
   }

--- a/src/components/MoviePreferenceType.tsx
+++ b/src/components/MoviePreferenceType.tsx
@@ -17,6 +17,7 @@ export default function MoviePreferenceType({
   if (preference == PreferenceType.positive) {
     return (
       <div
+        className="preferenceIcon"
         onClick={() =>
           updateMoviePreference(id, user, PreferenceType.negative, setMovies)
         }
@@ -27,6 +28,7 @@ export default function MoviePreferenceType({
   } else {
     return (
       <div
+        className="preferenceIcon"
         onClick={() =>
           updateMoviePreference(id, user, PreferenceType.positive, setMovies)
         }

--- a/src/network/requests.ts
+++ b/src/network/requests.ts
@@ -61,7 +61,7 @@ export const updateMoviePreference = async (
     body: JSON.stringify({ preference_type: preferenceType })
   });
   if (response.status !== 200) {
-    alert(`Failed to update movie preference.'`);
+    alert("Failed to update movie preference.");
   } else {
     fetchMovies(user, setMovies);
   }

--- a/src/network/requests.ts
+++ b/src/network/requests.ts
@@ -50,7 +50,7 @@ export const deleteMovie = (
 export const updateMoviePreference = async (
   id: number,
   user: User,
-  preference_type: PreferenceType,
+  preferenceType: PreferenceType,
   setMovies: SetMovies
 ) => {
   const response = await fetch(`users/${user.id}/movie-preferences/${id}`, {
@@ -58,7 +58,7 @@ export const updateMoviePreference = async (
     headers: {
       "Content-Type": "application/json; charset=utf-8"
     },
-    body: JSON.stringify({ preference_type: preference_type })
+    body: JSON.stringify({ preference_type: preferenceType })
   });
   if (response.status !== 200) {
     alert(`Failed to update movie preference.'`);

--- a/src/network/requests.ts
+++ b/src/network/requests.ts
@@ -54,7 +54,7 @@ export const updateMoviePreference = async (
   setMovies: SetMovies
 ) => {
   const response = await fetch(`users/${user.id}/movie-preferences/${id}`, {
-    method: "PUT",
+    method: "PATCH",
     headers: {
       "Content-Type": "application/json; charset=utf-8"
     },

--- a/src/network/requests.ts
+++ b/src/network/requests.ts
@@ -1,4 +1,4 @@
-import { MoviePreference, SetMovies, User } from "../types";
+import { MoviePreference, PreferenceType, SetMovies, User } from "../types";
 
 export const fetchMovies = (user: User, setMovies: SetMovies): void => {
   fetch(`/users/${user.id}/movie-preferences/`, {
@@ -45,4 +45,24 @@ export const deleteMovie = (
   })
     .then(response => response.json())
     .then(() => fetchMovies(user, setMovies));
+};
+
+export const updateMoviePreference = async (
+  id: number,
+  user: User,
+  preference_type: PreferenceType,
+  setMovies: SetMovies
+) => {
+  const response = await fetch(`users/${user.id}/movie-preferences/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8"
+    },
+    body: JSON.stringify({ preference_type: preference_type })
+  });
+  if (response.status !== 200) {
+    alert(`Failed to update movie preference.'`);
+  } else {
+    fetchMovies(user, setMovies);
+  }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface MoviePreference {
   user_id: number;
   external_movie_id: string;
   title: string;
-  preference_type: PreferenceType;
+  preferenceType: PreferenceType;
 }
 
 export type SetMovies = (movies: Array<MoviePreference>) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,11 +3,17 @@ export interface User {
   email: string;
 }
 
+export enum PreferenceType {
+  positive = "positive",
+  negative = "negative"
+}
+
 export interface MoviePreference {
   id: number;
   user_id: number;
   external_movie_id: string;
   title: string;
+  preference_type: PreferenceType;
 }
 
 export type SetMovies = (movies: Array<MoviePreference>) => void;


### PR DESCRIPTION
- Adds a preference type column to the `MoviePreference` model with a migration (will need to run `flask db upgrade` after this gets merged
- Adds a route for updating `MoviePreferences`
- Displays the type with emojis (✅ or 🔴 ) and lets you toggle by clicking

Drawbacks: still very slow to get user feedback once you toggle, will work on that in a follow-up PR.